### PR TITLE
Add a defer_target variable to declare the Ansible group name

### DIFF
--- a/docs/roles/cron/cron_drupal8.md
+++ b/docs/roles/cron/cron_drupal8.md
@@ -15,6 +15,10 @@ drupal:
         - minute: "*/{{ 10 | random(start=1) }}"
           # hour: 2
           job: cron
+  # If the sites are being deployed to an ASG, setting defer to true will create the crontab entry on the deploy server rather than all of the app servers.
+  defer: false
+  # If defer is set to true, the Ansible group name must be declared with defer_target. The first host in that group will be used in the crontab entry.
+  defer_target: ""
 
 ```
 

--- a/docs/roles/cron/cron_drupal8.md
+++ b/docs/roles/cron/cron_drupal8.md
@@ -17,7 +17,7 @@ drupal:
           job: cron
   # If the sites are being deployed to an ASG, setting defer to true will create the crontab entry on the deploy server rather than all of the app servers.
   defer: false
-  # If defer is set to true, the Ansible group name must be declared with defer_target. The first host in that group will be used in the crontab entry.
+  # If defer is set to true, the Ansible target must be declared with defer_target. If using a group, include the index. For example, _ce_www_dev[0]
   defer_target: ""
 
 ```

--- a/roles/cron/cron_drupal8/README.md
+++ b/roles/cron/cron_drupal8/README.md
@@ -15,6 +15,10 @@ drupal:
         - minute: "*/{{ 10 | random(start=1) }}"
           # hour: 2
           job: cron
+  # If the sites are being deployed to an ASG, setting defer to true will create the crontab entry on the deploy server rather than all of the app servers.
+  defer: false
+  # If defer is set to true, the Ansible group name must be declared with defer_target. The first host in that group will be used in the crontab entry.
+  defer_target: ""
 
 ```
 

--- a/roles/cron/cron_drupal8/README.md
+++ b/roles/cron/cron_drupal8/README.md
@@ -17,7 +17,7 @@ drupal:
           job: cron
   # If the sites are being deployed to an ASG, setting defer to true will create the crontab entry on the deploy server rather than all of the app servers.
   defer: false
-  # If defer is set to true, the Ansible group name must be declared with defer_target. The first host in that group will be used in the crontab entry.
+  # If defer is set to true, the Ansible target must be declared with defer_target. If using a group, include the index. For example, _ce_www_dev[0]
   defer_target: ""
 
 ```

--- a/roles/cron/cron_drupal8/defaults/main.yml
+++ b/roles/cron/cron_drupal8/defaults/main.yml
@@ -8,5 +8,7 @@ drupal:
         - minute: "*/{{ 10 | random(start=1) }}"
           # hour: 2
           job: cron
+  # If the sites are being deployed to an ASG, setting defer to true will create the crontab entry on the deploy server rather than all of the app servers.
   defer: false
+  # If defer is set to true, the Ansible group name must be declared with defer_target. The first host in that group will be used in the crontab entry.
   defer_target: ""

--- a/roles/cron/cron_drupal8/defaults/main.yml
+++ b/roles/cron/cron_drupal8/defaults/main.yml
@@ -9,3 +9,4 @@ drupal:
           # hour: 2
           job: cron
   defer: false
+  defer_target: ""

--- a/roles/cron/cron_drupal8/defaults/main.yml
+++ b/roles/cron/cron_drupal8/defaults/main.yml
@@ -10,5 +10,5 @@ drupal:
           job: cron
   # If the sites are being deployed to an ASG, setting defer to true will create the crontab entry on the deploy server rather than all of the app servers.
   defer: false
-  # If defer is set to true, the Ansible group name must be declared with defer_target. The first host in that group will be used in the crontab entry.
+  # If defer is set to true, the Ansible target must be declared with defer_target. If using a group, include the index. For example, _ce_www_dev[0]
   defer_target: ""

--- a/roles/cron/cron_drupal8/tasks/job.yml
+++ b/roles/cron/cron_drupal8/tasks/job.yml
@@ -5,7 +5,7 @@
 
 - name: Define cron job command if deferred (ASG).
   set_fact:
-    _cron_job_command: "cd {{ _ce_deploy_base_dir }} && ansible {{ drupal.defer_target }}[0] -m shell -a \"{{ _cron_job_command }}\""
+    _cron_job_command: "cd {{ _ce_deploy_base_dir }} && ansible {{ drupal.defer_target }} -m shell -a \"{{ _cron_job_command }}\""
   when:
     - drupal.defer is defined
     - drupal.defer

--- a/roles/cron/cron_drupal8/tasks/job.yml
+++ b/roles/cron/cron_drupal8/tasks/job.yml
@@ -5,10 +5,12 @@
 
 - name: Define cron job command if deferred (ASG).
   set_fact:
-    _cron_job_command: "cd {{ _ce_deploy_base_dir }} && ansible {{ inventory_hostname }}[0] -m command -a \" {{ _cron_job_command }}\""
+    _cron_job_command: "cd {{ _ce_deploy_base_dir }} && ansible {{ drupal.defer_target }}[0] -m shell -a \"{{ _cron_job_command }}\""
   when:
     - drupal.defer is defined
     - drupal.defer
+    - drupal.defer_target is defined
+    - drupal.defer_target | length > 0
 
 - name: Define cron job command for differing deploy users.
   set_fact:


### PR DESCRIPTION
In this line:

```yaml
delegate_to: "{{ 'localhost' if drupal.defer else inventory_hostname }}"
```

Does `inventory_hostname` need to change, or can it be left as is if we're not setting up the cron on the deploy server?