### PR TITLE
Rework cron setup

### DIFF
--- a/docs/roles/cron/cron_drupal8.md
+++ b/docs/roles/cron/cron_drupal8.md
@@ -19,6 +19,8 @@ drupal:
   defer: false
   # If defer is set to true, the Ansible target must be declared with defer_target. If using a group, include the index. For example, _ce_www_dev[0]
   defer_target: ""
+  # Drush location when installed with Composer
+  drush_location: "vendor/drush/drush/drush"
 
 ```
 

--- a/roles/cron/cron_drupal8/README.md
+++ b/roles/cron/cron_drupal8/README.md
@@ -19,6 +19,8 @@ drupal:
   defer: false
   # If defer is set to true, the Ansible target must be declared with defer_target. If using a group, include the index. For example, _ce_www_dev[0]
   defer_target: ""
+  # Drush location when installed with Composer
+  drush_location: "vendor/drush/drush/drush"
 
 ```
 

--- a/roles/cron/cron_drupal8/defaults/main.yml
+++ b/roles/cron/cron_drupal8/defaults/main.yml
@@ -12,3 +12,5 @@ drupal:
   defer: false
   # If defer is set to true, the Ansible target must be declared with defer_target. If using a group, include the index. For example, _ce_www_dev[0]
   defer_target: ""
+  # Drush location when installed with Composer
+  drush_location: "vendor/drush/drush/drush"

--- a/roles/cron/cron_drupal8/tasks/job.yml
+++ b/roles/cron/cron_drupal8/tasks/job.yml
@@ -1,7 +1,7 @@
 ---
 - name: Define cron job command.
   set_fact:
-    _cron_job_command: "cd {{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }} && {{ deploy_path }}/{{ webroot }}/{{ drupal.drush_location }} {{ entry.job }}"
+    _cron_job_command: "cd {{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }} && {{ deploy_path }}/{{ drupal.drush_location }} {{ entry.job }}"
 
 - name: Define cron job command if deferred (ASG).
   set_fact:

--- a/roles/cron/cron_drupal8/tasks/job.yml
+++ b/roles/cron/cron_drupal8/tasks/job.yml
@@ -1,7 +1,7 @@
 ---
 - name: Define cron job command.
   set_fact:
-    _cron_job_command: "cd {{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }} && {{ drush_bin }} {{ entry.job }}"
+    _cron_job_command: "cd {{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }} && {{ deploy_path }}/{{ webroot }}/{{ drupal.drush_location }} {{ entry.job }}"
 
 - name: Define cron job command if deferred (ASG).
   set_fact:
@@ -17,6 +17,8 @@
     _cron_job_command: "{{ _cron_job_command }} --extra-vars '{\"become\":true,\"become_user\":\"{{ www_user }}\"}'"
   when:
     - www_user != deploy_user
+    - drupal.defer is defined
+    - drupal.defer
 
 - name: Setup Drupal cron tasks on app server.
   cron:


### PR DESCRIPTION
When it comes to autoscale setups, when the ASG is rebuilt, the servers do not have `/home/deploy/.bin/drush.phar` in place, as that gets setup during a Drupal deployment. This means that until a prod deployment is done, the cron won't run successfully.

Here, I'm setting a sane default for a new variable, as with Drupal 8+, Drush is (usually) installed per site with Composer in `vendor/drush/drush/drush`. That can then be overridden in a site's deploy config.

Then, when the cron is setup, it will use the deploy path of the new build followed by the drush_location value.