### PR TITLE
Ensure sites/default is writable before trying to remove old code bases.

### DIFF
--- a/docs/roles/deploy_code.md
+++ b/docs/roles/deploy_code.md
@@ -26,6 +26,9 @@ deploy_code:
   # Wether to sync the local deploy base to a shared destination, after successful build.
   mount_sync: ""
   # mount_sync: "/home/{{ deploy_user }}/shared/{{ project_name }}_{{ build_type }}/deploy"
+  # Path that you want to make sure has 755 permissions. Make sure to include the webroot WITHOUT the slash.
+  perms_fix_path: ""
+  # perms_fix_path: "www/sites/default"
 
 ```
 

--- a/roles/deploy_code/README.md
+++ b/roles/deploy_code/README.md
@@ -26,6 +26,9 @@ deploy_code:
   # Wether to sync the local deploy base to a shared destination, after successful build.
   mount_sync: ""
   # mount_sync: "/home/{{ deploy_user }}/shared/{{ project_name }}_{{ build_type }}/deploy"
+  # Path that you want to make sure has 755 permissions. Make sure to include the webroot WITHOUT the slash.
+  perms_fix_path: ""
+  # perms_fix_path: "www/sites/default"
 
 ```
 

--- a/roles/deploy_code/defaults/main.yml
+++ b/roles/deploy_code/defaults/main.yml
@@ -18,3 +18,6 @@ deploy_code:
   # Wether to sync the local deploy base to a shared destination, after successful build.
   mount_sync: ""
   # mount_sync: "/home/{{ deploy_user }}/shared/{{ project_name }}_{{ build_type }}/deploy"
+  # Path that you want to make sure has 755 permissions. Make sure to include the webroot WITHOUT the slash.
+  perms_fix_path: ""
+  # perms_fix_path: "www/sites/default"

--- a/roles/deploy_code/tasks/cleanup.yml
+++ b/roles/deploy_code/tasks/cleanup.yml
@@ -6,6 +6,11 @@
   become: true
   when: "www_user != deploy_user"
 
+- name: Ensure sites/default is writable.
+  shell:
+    cmd: "if [ -d {{ deploy_path_prefix }}{{ item }} ]; then chmod 755 {{ deploy_path_prefix }}{{ item }}/{{ webroot }}/sites/default; fi"
+  with_sequence: start={{ [previous_build_number | int - 50, 0] | max }}  end={{ [previous_build_number | int - deploy_code.keep, 0] | max }}
+
 - name: Delete codebases.
   file:
     name: "{{ deploy_path_prefix }}{{ item }}"

--- a/roles/deploy_code/tasks/cleanup.yml
+++ b/roles/deploy_code/tasks/cleanup.yml
@@ -6,10 +6,13 @@
   become: true
   when: "www_user != deploy_user"
 
-- name: Ensure sites/default is writable.
+- name: Ensure permissions are set on directory.
   shell:
-    cmd: "if [ -d {{ deploy_path_prefix }}{{ item }} ]; then chmod 755 {{ deploy_path_prefix }}{{ item }}/{{ webroot }}/sites/default; fi"
+    cmd: "if [ -d {{ deploy_path_prefix }}{{ item }} ]; then chmod 755 {{ deploy_path_prefix }}{{ item }}/{{ deploy_code.perms_fix_path }}; fi"
   with_sequence: start={{ [previous_build_number | int - 50, 0] | max }}  end={{ [previous_build_number | int - deploy_code.keep, 0] | max }}
+  when:
+    - deploy_code.perms_fix_path is defined
+    - deploy_code.perms_fix_path | length > 1
 
 - name: Delete codebases.
   file:

--- a/roles/deploy_code/tasks/cleanup.yml
+++ b/roles/deploy_code/tasks/cleanup.yml
@@ -8,7 +8,7 @@
 
 - name: Ensure permissions are set on directory.
   shell:
-    cmd: "if [ -d {{ deploy_path_prefix }}{{ item }} ]; then chmod 755 {{ deploy_path_prefix }}{{ item }}/{{ deploy_code.perms_fix_path }}; fi"
+    cmd: "if [ -d {{ deploy_path_prefix }}{{ item }}/{{ deploy_code.perms_fix_path }} ]; then chmod 755 {{ deploy_path_prefix }}{{ item }}/{{ deploy_code.perms_fix_path }}; fi"
   with_sequence: start={{ [previous_build_number | int - 50, 0] | max }}  end={{ [previous_build_number | int - deploy_code.keep, 0] | max }}
   when:
     - deploy_code.perms_fix_path is defined


### PR DESCRIPTION
Sometimes the `sites/default` directory has permissions 555, either after a site install or some other process. So before we go to clear out old builds, we should first make sure that that directory is writable so it can be removed.