### PR TITLE
Drupal install profile

### DIFF
--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -30,6 +30,7 @@
      - [Data backups](/roles/database_backup)
        - [MySQL backups](/roles/database_backup/database_backup-mysql)
      - [Deploy](/roles/deploy_code)
+     - [Init](/roles/_init)
      - ["Meta"](/roles/_meta)
        - [Drupal 7](/roles/_meta/deploy-drupal7)
        - [Drupal 8](/roles/_meta/deploy-drupal8)

--- a/docs/roles/_init.md
+++ b/docs/roles/_init.md
@@ -1,3 +1,12 @@
+# Init
+These variables **must** be set in the `deploy/common.yml` file, at least.
+
+<!--TOC-->
+<!--ENDTOC-->
+
+<!--ROLEVARS-->
+## Default variables
+```yaml
 ---
 # Common defaults. Given the "_init" role is mandatory,
 # this will ensure defaults to other roles too.
@@ -23,3 +32,7 @@ drupal:
 mautic:
   image_path: "media/images"
   force_install: false
+
+```
+
+<!--ENDROLEVARS-->

--- a/roles/_init/README.md
+++ b/roles/_init/README.md
@@ -1,3 +1,12 @@
+# Init
+These variables **must** be set in the `deploy/common.yml` file, at least.
+
+<!--TOC-->
+<!--ENDTOC-->
+
+<!--ROLEVARS-->
+## Default variables
+```yaml
 ---
 # Common defaults. Given the "_init" role is mandatory,
 # this will ensure defaults to other roles too.
@@ -23,3 +32,7 @@ drupal:
 mautic:
   image_path: "media/images"
   force_install: false
+
+```
+
+<!--ENDROLEVARS-->

--- a/roles/_init/defaults/main.yml
+++ b/roles/_init/defaults/main.yml
@@ -13,6 +13,7 @@ drupal:
       sanitize_command: "sql-sanitize"
       base_url: https://www.example.com
       force_install: false
+      install_profile: "standard"
       cron:
         - minute: "*/{{ 10 | random(start=1) }}"
           job: cron

--- a/roles/_init/defaults/main.yml
+++ b/roles/_init/defaults/main.yml
@@ -13,7 +13,7 @@ drupal:
       sanitize_command: "sql-sanitize"
       base_url: https://www.example.com
       force_install: false
-      install_profile: "standard"
+      install_command: "-y si"
       cron:
         - minute: "*/{{ 10 | random(start=1) }}"
           job: cron

--- a/roles/database_apply/database_apply-drupal8/defaults/main.yml
+++ b/roles/database_apply/database_apply-drupal8/defaults/main.yml
@@ -1,7 +1,0 @@
----
-# This role takes its parameters from the "drupal.sites" variables directly.
-drupal:
-  sites:
-    - folder: "default"
-      # ... See the _init role for other variables.
-      install_command: "-y si"

--- a/roles/database_apply/database_apply-drupal8/defaults/main.yml
+++ b/roles/database_apply/database_apply-drupal8/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# This role takes its parameters from the "drupal.sites" variables directly.
+drupal:
+  sites:
+    - folder: "default"
+      # ... See the _init role for other variables.
+      install_command: "-y si"

--- a/roles/database_apply/database_apply-drupal8/tasks/main.yml
+++ b/roles/database_apply/database_apply-drupal8/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Install Drupal.
   command:
-    cmd: "{{ drush_bin }} -y si"
+    cmd: "{{ drush_bin }} -y si {{ site.install_profile }}"
     chdir: "{{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }}"
   become: "{{ 'no' if www_user == deploy_user else 'yes' }}"
   become_user: "{{ www_user }}"

--- a/roles/database_apply/database_apply-drupal8/tasks/main.yml
+++ b/roles/database_apply/database_apply-drupal8/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Install Drupal.
   command:
-    cmd: "{{ drush_bin }} -y si {{ site.install_profile }}"
+    cmd: "{{ drush_bin }} {{ site.install_command }}"
     chdir: "{{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }}"
   become: "{{ 'no' if www_user == deploy_user else 'yes' }}"
   become_user: "{{ www_user }}"


### PR DESCRIPTION
So far, I'm not sure about this. It means new sites *have* to have the `install_command` variable in their deploy files somewhere, but that is already the case for the `config_import_command` variable, so maybe it's fine? This should only be a requirement for new deployments, or if the `force_install` variable is set.

I did try setting defaults in the database_apply-drupal8 role, but that didn't work.

I'm also adding some documentation to the _init role, which provides information on which variables are required.