### PR TITLE
Fixing a bug where Chrome would crash during lighthouse run PR 1.x

### DIFF
--- a/roles/lhci_run/README.md
+++ b/roles/lhci_run/README.md
@@ -5,6 +5,8 @@ Step that runs LHCI against the codebase. Requires LHCI and Google Chrome to be 
 
 This role is automatically present in preset ce-dev images on Docker Hub so you can just use `lhci_run` for local testing directly.
 
+For more information on LHCI, see https://github.com/GoogleChrome/lighthouse-ci/blob/main/docs/getting-started.md
+
 <!--TOC-->
 <!--ENDTOC-->
 
@@ -26,11 +28,21 @@ lhci_run:
   chrome_flags:
     - "--no-sandbox"
     - "--ignore-certificate-errors"
+    - "--disable-dev-shm-usage"
   # Optional lists of audits to explicitly skip or run.
-  skip_audits:
-    - "full-page-screenshot" # We exclude this by default as it causes problems on some websites.
+  skip_audits: []
   only_audits: []
 
 ```
 
 <!--ENDROLEVARS-->
+
+The role installs `Xvfb` for 'headful' running of Google Chrome. This is preconfigured to run in the background with a display ID of 99, so you should run this command before running any `lhci` tests to ensure Chrome has an X session to run in:
+
+```
+export DISPLAY=:99
+```
+
+To view the `Xvfb` display, from inside the web container run `x11vnc -display :99 &`
+
+You can then connect from your host machine using a VNC client, such as https://tigervnc.org. You'll need to specify the internal IP of the web container, which you can find in your hosts file.

--- a/roles/lhci_run/defaults/main.yml
+++ b/roles/lhci_run/defaults/main.yml
@@ -13,7 +13,7 @@ lhci_run:
   chrome_flags:
     - "--no-sandbox"
     - "--ignore-certificate-errors"
+    - "--disable-dev-shm-usage"
   # Optional lists of audits to explicitly skip or run.
-  skip_audits:
-    - "full-page-screenshot" # We exclude this by default as it causes problems on some websites.
+  skip_audits: []
   only_audits: []


### PR DESCRIPTION
We were running into the same issue as described at https://github.com/GoogleChrome/lighthouse-ci/issues/428, but only for some web pages. Eventually tracked it down to this underlying issue, https://bugs.chromium.org/p/chromium/issues/detail?id=715363, and passing the Chrome flag `--disable-dev-shm-usage` cured the problem.

Amended the default config to include that flag, and updated the README to match.