### PR TITLE
Matomo core update confirmation PR 1.x

### DIFF
--- a/roles/database_apply/database_apply-matomo/tasks/main.yml
+++ b/roles/database_apply/database_apply-matomo/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Apply Matomo database updates.
   command:
-    cmd: "{{ deploy_path }}/{{ webroot }}/console core:update"
+    cmd: "{{ deploy_path }}/{{ webroot }}/console core:update --yes"
     chdir: "{{ deploy_path }}/{{ webroot }}"
   become: "{{ 'no' if www_user == deploy_user else 'yes' }}"
   become_user: "{{ www_user }}"


### PR DESCRIPTION
The matomo `console core:update` command waits for user confirmation, so was causing deployments to hang at that step. Appending `--yes` fixes the problem.