### PR TITLE
Defer nightly backups

### DIFF
--- a/roles/cron/cron_database_backup/cron_database_backup-mysql/tasks/main.yml
+++ b/roles/cron/cron_database_backup/cron_database_backup-mysql/tasks/main.yml
@@ -3,6 +3,15 @@
 # screwing the daily backup when using rolling db, we could
 # add a keep mechanism for backup scripts, like for the dumps themselves.
 # Nice to have more than anything.
+- name: Setup PATH in crontab.
+  cron:
+    name: PATH
+    env: true
+    job: "/usr/bin:/usr/local/bin:/bin:/home/{{ deploy_user }}/.bin"
+  when:
+    - drupal.defer is defined
+    - drupal.defer
+
 - include_tasks: setup.yml
   vars:
     database: database

--- a/roles/cron/cron_database_backup/cron_database_backup-mysql/tasks/setup.yml
+++ b/roles/cron/cron_database_backup/cron_database_backup-mysql/tasks/setup.yml
@@ -25,12 +25,26 @@
 - name: Create backup script.
   template:
     src: "regular-backups.sh.j2"
-    dest: "/home/{{ deploy_user }}/{{ database.host }}-{{ database.original.database }}-regular-backups.sh"
+    dest: "/home/{{ deploy_user }}/shared/{{ project_name }}_{{ build_type }}/{{ database.host }}-{{ database.original.database }}-regular-backups.sh"
     mode: 0700
+
+- name: Define backup cron job command.
+  set_fact:
+    _backup_cron_job_command: "/bin/sh /home/{{ deploy_user }}/shared/{{ project_name }}_{{ build_type }}/{{ database.host }}-{{ database.original.database }}-regular-backups.sh"
+
+- name: Define backup cron job command if deferred (ASG).
+  set_fact:
+    _backup_cron_job_command: "cd {{ _ce_deploy_base_dir }} && {{ _ce_deploy_ansible_location }} {{ drupal.defer_target }} -m shell -a \"{{ _backup_cron_job_command }}\""
+  when:
+    - drupal.defer is defined
+    - drupal.defer
+    - drupal.defer_target is defined
+    - drupal.defer_target | length > 0
 
 - name: Setup regular backup for MySQL.
   cron:
     name: "cron_mysql_{{ database.host }}_{{ database.original.database }}"
     minute: "{{ _cron_mysql_backup_minute }}"
     hour: "{{ _cron_mysql_backup_hour }}"
-    job: "/bin/sh /home/{{ deploy_user }}/{{ database.host }}-{{ database.original.database }}-regular-backups.sh"
+    job: "{{ _backup_cron_job_command }}"
+  delegate_to: "{{ 'localhost' if drupal.defer else inventory_hostname }}"

--- a/roles/cron/cron_database_backup/cron_database_backup-mysql/tasks/setup.yml
+++ b/roles/cron/cron_database_backup/cron_database_backup-mysql/tasks/setup.yml
@@ -47,4 +47,6 @@
     minute: "{{ _cron_mysql_backup_minute }}"
     hour: "{{ _cron_mysql_backup_hour }}"
     job: "{{ _backup_cron_job_command }}"
+    cron_file: "{{ project_name }}-{{ build_type }}"
+    user: "{{ deploy_user }}"
   delegate_to: "{{ 'localhost' if drupal.defer else inventory_hostname }}"


### PR DESCRIPTION
Now, should we be creating files in `/etc/cron.d` for these instead of them being added to the deploy user's crontab? I ask because in some cases, there could be *a lot* of sites (one of our clients falls into this category), which would mean the crontab for the deploy user is massive (and it already is for that client), which makes it messy and difficult to manage.

But also, I think if the location of the script changes, I'm not sure if the existing entry in the crontab will be edited. Instead, I think a new one will be created, so there would be two cron entries for nightly backups.

The reason I'm moving the script is because it, too, needs to persist after an ASG rebuild, so if it's in `/home/deploy`, it **won't** persist, but if it's in `/home/deploy/shared` it will, because that's an EFS mount on ASGs.