### PR TITLE
Improve multisite support

### DIFF
--- a/roles/cache_clear/cache_clear-drupal7/tasks/main.yml
+++ b/roles/cache_clear/cache_clear-drupal7/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Clear Drupal 7 cache.
   command:
-    cmd: "{{ drush_bin }} -y cc all"
+    cmd: "{{ drush_bin }} -y cc all -l {{ site.folder }}"
     chdir: "{{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }}"
   become: "{{ 'no' if www_user == deploy_user else 'yes' }}"
   become_user: "{{ www_user }}"

--- a/roles/cache_clear/cache_clear-drupal8/tasks/main.yml
+++ b/roles/cache_clear/cache_clear-drupal8/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Clear Drupal cache.
   command:
-    cmd: "{{ drush_bin }} -y cr"
+    cmd: "{{ drush_bin }} -y cr -l {{ site.folder }}"
     chdir: "{{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }}"
   become: "{{ 'no' if www_user == deploy_user else 'yes' }}"
   become_user: "{{ www_user }}"

--- a/roles/cron/cron_database_backup/cron_database_backup-mysql/tasks/setup.yml
+++ b/roles/cron/cron_database_backup/cron_database_backup-mysql/tasks/setup.yml
@@ -47,4 +47,4 @@
     minute: "{{ _cron_mysql_backup_minute }}"
     hour: "{{ _cron_mysql_backup_hour }}"
     job: "{{ _backup_cron_job_command }}"
-  delegate_to: "{{ 'localhost' if drupal.defer else inventory_hostname }}"
+  delegate_to: "{{ 'localhost' if drupal.defer is defined and drupal.defer else inventory_hostname }}"

--- a/roles/database_apply/database_apply-drupal7/tasks/features.yml
+++ b/roles/database_apply/database_apply-drupal7/tasks/features.yml
@@ -1,8 +1,8 @@
 ---
 - name: Check if Features module is enabled.
-  shell: "cd {{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }} && {{ drush_bin }} pm-info features | grep ':  enabled' | wc -l"
+  shell: "cd {{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }} && {{ drush_bin }} pm-info features -l {{ site.folder }} | grep ':  enabled' | wc -l"
   register: features_enabled
 
 - name: Revert Drupal configuration from Features.
-  shell: "cd {{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }} && {{ drush_bin }} -y {{ site.revert_features_command }}"
+  shell: "cd {{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }} && {{ drush_bin }} -y {{ site.revert_features_command }} -l {{ site.folder }}"
   when: features_enabled.stdout == "1"

--- a/roles/database_apply/database_apply-drupal7/tasks/main.yml
+++ b/roles/database_apply/database_apply-drupal7/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Install Drupal.
   shell:
-    cmd: "{{ drush_bin }} -y si"
+    cmd: "{{ drush_bin }} -y si -l {{ site.folder }}"
     chdir: "{{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }}"
   become: "{{ 'no' if www_user == deploy_user else 'yes' }}"
   become_user: "{{ www_user }}"
@@ -21,7 +21,7 @@
 
 - name: Apply Drupal database updates.
   shell:
-    cmd: "{{ drush_bin }} -y updb"
+    cmd: "{{ drush_bin }} -y updb -l {{ site.folder }}"
     chdir: "{{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }}"
   with_items: "{{ drupal.sites }}"
   loop_control:

--- a/roles/database_apply/database_apply-drupal8/tasks/main.yml
+++ b/roles/database_apply/database_apply-drupal8/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Install Drupal.
   command:
-    cmd: "{{ drush_bin }} {{ site.install_command }}"
+    cmd: "{{ drush_bin }} {{ site.install_command }} -l {{ site.folder }}"
     chdir: "{{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }}"
   become: "{{ 'no' if www_user == deploy_user else 'yes' }}"
   become_user: "{{ www_user }}"
@@ -34,7 +34,7 @@
 
 - name: Apply Drupal database updates.
   command:
-    cmd: "{{ drush_bin }} -y updb"
+    cmd: "{{ drush_bin }} -y updb -l {{ site.folder }}"
     chdir: "{{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }}"
   become: "{{ 'no' if www_user == deploy_user else 'yes' }}"
   become_user: "{{ www_user }}"
@@ -44,7 +44,7 @@
 
 - name: Import configuration.
   command:
-    cmd: "{{ drush_bin }} -y {{ site.config_import_command }}"
+    cmd: "{{ drush_bin }} -y {{ site.config_import_command }} -l {{ site.folder }}"
     chdir: "{{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }}"
   become: "{{ 'no' if www_user == deploy_user else 'yes' }}"
   become_user: "{{ www_user }}"

--- a/roles/maintenance_mode/maintenance_mode-drupal-core/tasks/offline.yml
+++ b/roles/maintenance_mode/maintenance_mode-drupal-core/tasks/offline.yml
@@ -2,7 +2,7 @@
 # @todo this needs refactoring for multisite.
 - name: Enable maintenance mode.
   command:
-    cmd: "{{ drush_bin }} state:set system.maintenance_mode 1 --input-format=integer"
+    cmd: "{{ drush_bin }} state:set system.maintenance_mode 1 --input-format=integer -l {{ site.folder }}"
     chdir: "{{ live_symlink_dest }}/{{ webroot }}/sites/{{ site.folder }}"
   become: "{{ 'no' if www_user == deploy_user else 'yes' }}"
   become_user: "{{ www_user }}"
@@ -12,7 +12,7 @@
 
 - name: Enable maintenance mode D7.
   shell:
-    cmd: "{{ drush_bin }} vset maintenance_mode 1"
+    cmd: "{{ drush_bin }} vset maintenance_mode 1 -l {{ site.folder }}"
     chdir: "{{ live_symlink_dest }}/{{ webroot }}/sites/{{ site.folder }}"
   become: "{{ 'no' if www_user == deploy_user else 'yes' }}"
   become_user: "{{ www_user }}"

--- a/roles/maintenance_mode/maintenance_mode-drupal-core/tasks/online.yml
+++ b/roles/maintenance_mode/maintenance_mode-drupal-core/tasks/online.yml
@@ -1,7 +1,7 @@
 ---
 - name: Disable maintenance mode.
   command:
-    cmd: "{{ drush_bin }} state:set system.maintenance_mode 0 --input-format=integer"
+    cmd: "{{ drush_bin }} state:set system.maintenance_mode 0 --input-format=integer -l {{ site.folder }}"
     chdir: "{{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }}"
   become: "{{ 'no' if www_user == deploy_user else 'yes' }}"
   become_user: "{{ www_user }}"
@@ -10,7 +10,7 @@
 
 - name: Disable maintenance mode D7.
   shell:
-    cmd: "{{ drush_bin }} vset maintenance_mode 0"
+    cmd: "{{ drush_bin }} vset maintenance_mode 0 -l {{ site.folder }}"
     chdir: "{{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }}"
   become: "{{ 'no' if www_user == deploy_user else 'yes' }}"
   become_user: "{{ www_user }}"

--- a/roles/sanitize/admin_creds/admin_creds-drupal7/tasks/admin.yml
+++ b/roles/sanitize/admin_creds/admin_creds-drupal7/tasks/admin.yml
@@ -6,6 +6,6 @@
     _admin_pwd: "{{ lookup('password', '/tmp/{{ project_name }}-{{ site.folder }}-{{ build_type }}-{{ build_number }}-pwd chars=ascii_letters') }}"
 
 - name: Reset admin username.
-  shell: "cd {{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }} && {{ drush_bin }} sql-query \"UPDATE users SET name='{{ _admin_user }}' WHERE uid=1;\""
+  shell: "cd {{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }} && {{ drush_bin }} sql-query \"UPDATE users SET name='{{ _admin_user }}' WHERE uid=1;\" -l {{ site.folder }}"
 - name: Reset admin password.
-  shell: "cd {{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }} && {{ drush_bin }} upwd {{ _admin_user }} --password='{{ _admin_pwd }}'"
+  shell: "cd {{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }} && {{ drush_bin }} upwd {{ _admin_user }} --password='{{ _admin_pwd }}' -l {{ site.folder }}"

--- a/roles/sanitize/admin_creds/admin_creds-drupal8/tasks/admin.yml
+++ b/roles/sanitize/admin_creds/admin_creds-drupal8/tasks/admin.yml
@@ -4,14 +4,14 @@
 # Loading the user directly is akward, but at least means we don't bypass entity update.
 - name: Reset admin username.
   command:
-    cmd: "{{ drush_bin }} php-eval '$admin = \\Drupal\\user\\Entity\\User::load(1); $admin->setUsername(\"{{ admin_creds.username }}\");$admin->save();' "
+    cmd: "{{ drush_bin }} php-eval '$admin = \\Drupal\\user\\Entity\\User::load(1); $admin->setUsername(\"{{ admin_creds.username }}\");$admin->save();' -l {{ site.folder }}"
     chdir: "{{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }}"
   when:
     - admin_creds.username | length > 1
 
 - name: Reset admin password.
   command:
-    cmd: "{{ drush_bin }} php-eval '$admin = \\Drupal\\user\\Entity\\User::load(1); $admin->setPassword(\"{{ admin_creds.password }}\");$admin->save();' "
+    cmd: "{{ drush_bin }} php-eval '$admin = \\Drupal\\user\\Entity\\User::load(1); $admin->setPassword(\"{{ admin_creds.password }}\");$admin->save();' -l {{ site.folder }}"
     chdir: "{{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }}"
   when:
     - admin_creds.password | length > 1

--- a/roles/sanitize/sanitize-drupal8/tasks/main.yml
+++ b/roles/sanitize/sanitize-drupal8/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Sanitize database.
   command:
-    cmd: "{{ drush_bin }} -y {{ site.sanitize_command }}"
+    cmd: "{{ drush_bin }} -y {{ site.sanitize_command }} -l {{ site.folder }}"
     chdir: "{{ live_symlink_dest }}/{{ webroot }}/sites/{{ site.folder }}"
   become: "{{ 'no' if www_user == deploy_user else 'yes' }}"
   become_user: "{{ www_user }}"


### PR DESCRIPTION
In order to properly support multisites that use separate databases, and for cases where multisites are deployed separately to one another, we need to pass through the `-l` option when running Drush commands.

It's fine to pass that through when the **default** site is used.

This has been tested in `devel`, but for now this PR is a draft and I'll do some more testing.