### PR TITLE
Making contents of deploy tar 'ownerless'.

### DIFF
--- a/roles/deploy_code/tasks/cleanup.yml
+++ b/roles/deploy_code/tasks/cleanup.yml
@@ -22,7 +22,7 @@
 
 - name: Create a tarball of the deployed codebases.
   ansible.builtin.command:
-    cmd: "tar -cvf /tmp/{{ project_name }}_{{ build_type }}.tar {{ deploy_base_path }}"
+    cmd: "tar -cvf /tmp/{{ project_name }}_{{ build_type }}.tar --owner=0 --group=0 {{ deploy_base_path }}"
   when:
     - deploy_code.mount_sync is defined
     - deploy_code.mount_sync | length > 1


### PR DESCRIPTION
This needs to be applied carefully and in conjunction with ce-provision changes to the `mount_sync` role.