### PR TITLE
Changed where drush.yml is written to, so it can be used to set the site's uri.

### DIFF
--- a/roles/config_generate/config_generate-drupal8/tasks/drush.yml
+++ b/roles/config_generate/config_generate-drupal8/tasks/drush.yml
@@ -2,7 +2,7 @@
 - name: Generates drush.yml file.
   ansible.builtin.template:
     src: '{{ item }}'
-    dest: "{{ deploy_path }}/{{ webroot }}/sites/{{ site.folder }}/drush.yml"
+    dest: "{{ deploy_path }}/drush/drush.yml"
   with_first_found:
     - "{{ playbook_dir }}/{{ webroot }}/sites/{{ site.folder }}/{{ build_type }}.{{ config_generate_drupal.drush_settings_file_name }}.j2"
     - "{{ _ce_deploy_build_dir }}/{{ webroot }}/sites/{{ site.folder }}/{{ build_type }}.{{ config_generate_drupal.drush_settings_file_name }}"


### PR DESCRIPTION
I've been trying to use drush.yml to set the site's URL in drush. Without this, URLs in the search index, and sitemap.xml end up with a domain of 'default' when generated in code called by drush.

Currently, the task that generates drush.yml writes a file to set the uri option to sites/default/drush.yml, but this makes no difference to the site's URI.

As per [this comment from Moshe](https://github.com/drush-ops/drush/issues/3121#issuecomment-364802730), drush.yml in a site directory is valid, but too late to set the uri. Setting it in drush/drush.yml does work. I've tried this on stage by moving the generated file to that path, and it works as expected.

As URI is the only option that ce-deploy currently supports in drush.yml, here's a PR to move the file so that option works.